### PR TITLE
fix: `edge_index.dtype` is `float`

### DIFF
--- a/adbpyg_adapter/adapter.py
+++ b/adbpyg_adapter/adapter.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from math import ceil
 from typing import Any, Callable, DefaultDict, Dict, List, Optional, Set, Tuple, Union
 
+import numpy as np
 import torch
 from arango.cursor import Cursor
 from arango.database import StandardDatabase
@@ -912,7 +913,10 @@ class ADBPyG_Adapter(Abstract_ADBPyG_Adapter):
             to_n = et_df["to_key"].map(adb_map[to_col]).fillna(-1).astype(int)
 
             # 6. Set/Update the PyG Edge Index
-            edge_index = tensor([from_n.tolist(), to_n.tolist()], dtype=torch.int64)
+            edge_index = tensor(
+                np.array([from_n.to_numpy(), to_n.to_numpy()]), dtype=torch.int64
+            )
+
             empty_tensor = torch.tensor([], dtype=torch.int64)
             existing_edge_index = edge_data.get("edge_index", empty_tensor)
             edge_data.edge_index = torch.cat((existing_edge_index, edge_index), dim=1)

--- a/adbpyg_adapter/adapter.py
+++ b/adbpyg_adapter/adapter.py
@@ -904,24 +904,28 @@ class ADBPyG_Adapter(Abstract_ADBPyG_Adapter):
             ]
 
             # 5. Map each ArangoDB from/to _key to the corresponding PyG node id
-            from_nodes = et_df["from_key"].map(adb_map[from_col]).tolist()
-            to_nodes = et_df["to_key"].map(adb_map[to_col]).tolist()
+            # NOTE: map() is somehow converting int values to float...
+            # So we rely on astype(int) to convert the float back to int,
+            # but we also fill NaN values with -1 so that we can convert
+            # the entire column to int without any issues. Need to revisit...
+            from_n = et_df["from_key"].map(adb_map[from_col]).fillna(-1).astype(int)
+            to_n = et_df["to_key"].map(adb_map[to_col]).fillna(-1).astype(int)
 
             # 6. Set/Update the PyG Edge Index
-            edge_index = tensor([from_nodes, to_nodes])
-            edge_data.edge_index = torch.cat(
-                (edge_data.get("edge_index", tensor([])), edge_index), dim=1
-            )
+            edge_index = tensor([from_n.tolist(), to_n.tolist()], dtype=torch.int64)
+            empty_tensor = torch.tensor([], dtype=torch.int64)
+            existing_edge_index = edge_data.get("edge_index", empty_tensor)
+            edge_data.edge_index = torch.cat((existing_edge_index, edge_index), dim=1)
 
             # 7. Deal with invalid edges
-            if torch.any(torch.isnan(edge_data.edge_index)):
+            if torch.any(edge_data.edge_index == -1):
                 if strict:
                     m = f"Invalid edges found in Edge Collection {e_col}, {from_col} -> {to_col}."  # noqa: E501
                     raise InvalidADBEdgesError(m)
                 else:
                     # Remove the invalid edges
                     edge_data.edge_index = edge_data.edge_index[
-                        :, ~torch.any(edge_data.edge_index.isnan(), dim=0)
+                        :, ~torch.any(edge_data.edge_index == -1, dim=0)
                     ]
 
             # 8. Set the PyG Edge Data

--- a/adbpyg_adapter/adapter.py
+++ b/adbpyg_adapter/adapter.py
@@ -917,9 +917,9 @@ class ADBPyG_Adapter(Abstract_ADBPyG_Adapter):
                 np.array([from_n.to_numpy(), to_n.to_numpy()]), dtype=torch.int64
             )
 
-            empty_tensor = torch.tensor([], dtype=torch.int64)
+            empty_tensor = tensor([], dtype=torch.int64)
             existing_edge_index = edge_data.get("edge_index", empty_tensor)
-            edge_data.edge_index = torch.cat((existing_edge_index, edge_index), dim=1)
+            edge_data.edge_index = cat((existing_edge_index, edge_index), dim=1)
 
             # 7. Deal with invalid edges
             if torch.any(edge_data.edge_index == -1):


### PR DESCRIPTION
The `__process_adb_edge_df` method is responsible for creating & appending to an `EdgeStorage`'s `edge_index`.

Part of this code is responsible for mapping the ArangoDB Edges `_from` and `_to` values to the ArangoDB Vertex Collection Map (`adb_map`) to preserve the zero-based index value associated to the `_from` and `_to` IDs.

For a reason (not yet know), this mapping is returning a Pandas Series of **floats** instead of **integers**. These values are then piped into the `edge_index` property, resulting in `edge_index.dtype` being `float`...

This PR aims to address this issue by invoking `astype(int)` after invoking the Pandas `map()` function.
- However, invoking `astype(int)` on a Pandas Series with possible `NaN` values will raise, so we must also introduce `fillna(-1)`. This in turn affects the handling of Invalid Edges, hence why that code was also modified
